### PR TITLE
Preparation for Native Git Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -120,12 +120,14 @@
                 <executions>
                     <execution>
                         <id>compile</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
                         </goals>
                     </execution>
                     <execution>
                         <id>test-compile</id>
+                        <phase>test-compile</phase>
                         <goals>
                             <goal>test-compile</goal>
                         </goals>
@@ -144,35 +146,45 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>${maven-gpg-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <gpgArguments>
-                        <arg>--pinentry-mode</arg>
-                        <arg>loopback</arg>
-                    </gpgArguments>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>${nexus-staging-plugin.version}</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>${nexus-staging-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <jdom2.version>2.0.6</jdom2.version>
         <jaxen.version>1.1.6</jaxen.version>
-        <junit.jupiter.version>5.6.0</junit.jupiter.version>
     </properties>
 
     <dependencies>
@@ -102,12 +101,8 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.6.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -118,17 +113,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.jupiter.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <nexus-staging-plugin.version>1.6.8</nexus-staging-plugin.version>
         <jdom2.version>2.0.6</jdom2.version>
         <jaxen.version>1.1.6</jaxen.version>
+        <junit.jupiter.version>5.6.0</junit.jupiter.version>
     </properties>
 
     <dependencies>
@@ -99,7 +100,35 @@
             <artifactId>woodstox-core-asl</artifactId>
             <version>4.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.15.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <sourceDirectory>src/main/kotlin</sourceDirectory>
@@ -145,6 +174,10 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/kotlin/com/github/helpermethod/GitProvider.kt
+++ b/src/main/kotlin/com/github/helpermethod/GitProvider.kt
@@ -1,0 +1,11 @@
+package com.github.helpermethod
+
+interface GitProvider : AutoCloseable {
+
+    fun hasRemoteBranch(branchName: String) : Boolean
+
+    fun checkout(branchName: String)
+    fun add(filePattern: String)
+    fun commit(author: String, message: String)
+    fun push(branchName: String)
+}

--- a/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
+++ b/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
@@ -1,0 +1,81 @@
+package com.github.helpermethod
+
+import com.jcraft.jsch.Session
+import org.apache.maven.settings.Settings
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.ListBranchCommand
+import org.eclipse.jgit.api.TransportConfigCallback
+import org.eclipse.jgit.lib.PersonIdent
+import org.eclipse.jgit.transport.*
+import org.eclipse.jgit.util.FS
+
+// TODO: interaction test
+class JGitProvider(val git: Git, val connection: String, val settings: Settings) : GitProvider {
+    override fun hasRemoteBranch(branchName: String): Boolean {
+        return git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call().none { it.name == "refs/remotes/origin/$branchName" }
+    }
+
+    override fun checkout(branchName: String) {
+        git
+                .checkout()
+                .setStartPoint(git.repository.fullBranch)
+                .setCreateBranch(true)
+                .setName(branchName)
+                .call()
+
+    }
+
+    override fun add(filePattern: String) {
+        git.add()
+                .addFilepattern(filePattern)
+                .call()
+    }
+
+    override fun commit(author: String, message: String) {
+        git.commit()
+                .setAuthor(PersonIdent(author, ""))
+                .setMessage(message)
+                .call()
+    }
+
+    override fun push(branchName: String) {
+        git
+                .push()
+                .setRefSpecs(RefSpec("$branchName:$branchName"))
+                .apply {
+                    val uri = URIish(connection.removePrefix("scm:git:"))
+
+                    when (uri.scheme) {
+                        "https" -> {
+                            val (username, password) = usernamePassword(uri)
+
+                            setCredentialsProvider(UsernamePasswordCredentialsProvider(username, password))
+                        }
+                        else -> {
+                            setTransportConfigCallback(TransportConfigCallback { transport ->
+                                if (transport !is SshTransport) return@TransportConfigCallback
+
+                                transport.sshSessionFactory = object : JschConfigSessionFactory() {
+                                    override fun configure(hc: OpenSshConfig.Host?, session: Session?) {
+                                    }
+
+                                    override fun createDefaultJSch(fs: FS?) =
+                                            settings.getServer(uri.host).run {
+                                                super.createDefaultJSch(fs).apply { addIdentity(privateKey, passphrase) }
+                                            }
+                                }
+                            })
+                        }
+                    }
+                }
+                .setPushOptions(listOf("merge_request.create"))
+                .call()
+    }
+
+    override fun close() {
+        git.close()
+    }
+
+    private fun usernamePassword(uri: URIish) =
+            if (uri.user != null) uri.user to uri.pass else settings.getServer(uri.host).run { username to password }
+}

--- a/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
+++ b/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
@@ -11,7 +11,7 @@ import org.eclipse.jgit.util.FS
 
 // TODO: interaction test
 class JGitProvider(val git: Git, val connection: String, val settings: Settings) : GitProvider {
-    override fun hasRemoteBranch(branchName: String): Boolean =
+    override fun hasRemoteBranch(branchName: String) =
             git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call().none { it.name == "refs/remotes/origin/$branchName" }
 
     override fun checkout(branchName: String) {

--- a/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
+++ b/src/main/kotlin/com/github/helpermethod/JGitProvider.kt
@@ -11,9 +11,8 @@ import org.eclipse.jgit.util.FS
 
 // TODO: interaction test
 class JGitProvider(val git: Git, val connection: String, val settings: Settings) : GitProvider {
-    override fun hasRemoteBranch(branchName: String): Boolean {
-        return git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call().none { it.name == "refs/remotes/origin/$branchName" }
-    }
+    override fun hasRemoteBranch(branchName: String): Boolean =
+            git.branchList().setListMode(ListBranchCommand.ListMode.ALL).call().none { it.name == "refs/remotes/origin/$branchName" }
 
     override fun checkout(branchName: String) {
         git

--- a/src/main/kotlin/com/github/helpermethod/UpdateMojo.kt
+++ b/src/main/kotlin/com/github/helpermethod/UpdateMojo.kt
@@ -74,11 +74,7 @@ class UpdateMojo: AbstractMojo() {
                 .build()
         ), connection, settings)
 
-        git.use{
-            f(git)
-        }
-
-
+        git.use(f)
     }
 
     private fun withPom(f: (Document) -> Unit) {

--- a/src/main/kotlin/com/github/helpermethod/UpdateMojo.kt
+++ b/src/main/kotlin/com/github/helpermethod/UpdateMojo.kt
@@ -1,6 +1,5 @@
 package com.github.helpermethod
 
-import com.jcraft.jsch.Session
 import org.apache.maven.artifact.Artifact
 import org.apache.maven.artifact.factory.ArtifactFactory
 import org.apache.maven.artifact.metadata.ArtifactMetadataSource
@@ -15,17 +14,12 @@ import org.apache.maven.settings.Settings
 import org.codehaus.stax2.XMLInputFactory2
 import org.codehaus.stax2.XMLInputFactory2.P_PRESERVE_LOCATION
 import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.api.ListBranchCommand.ListMode.ALL
-import org.eclipse.jgit.api.TransportConfigCallback
-import org.eclipse.jgit.lib.PersonIdent
 import org.eclipse.jgit.lib.RepositoryBuilder
 import org.eclipse.jgit.transport.*
-import org.eclipse.jgit.util.FS
 import org.jdom2.Document
 import org.jdom2.filter.Filters.element
 import org.jdom2.input.StAXStreamBuilder
 import org.jdom2.output.Format
-import org.jdom2.output.LineSeparator
 import org.jdom2.output.LineSeparator.NONE
 import org.jdom2.output.XMLOutputter
 import org.jdom2.xpath.XPathFactory
@@ -54,82 +48,37 @@ class UpdateMojo: AbstractMojo() {
         get() = if (connectionType == "developerConnection") developerConnectionUrl else connectionUrl
 
     override fun execute() {
-        withGit { git, head ->
+        withGit { git ->
             listOf(::parentUpdate, ::dependencyManagementUpdates, ::dependencyUpdates)
                 .flatMap { it() }
                 .map { it to "dependency-update/${it.groupId}-${it.artifactId}-${it.latestVersion}" }
-                .filter { (_, branchName) -> git.branchList().setListMode(ALL).call().none { it.name == "refs/remotes/origin/$branchName" }}
+                .filter { (_, branchName) -> git.hasRemoteBranch(branchName)}
                 .forEach { (update, branchName) ->
-                    git
-                        .checkout()
-                        .setStartPoint(head)
-                        .setCreateBranch(true)
-                        .setName(branchName)
-                        .call()
-
+                    git.checkout(branchName)
                     withPom(update.modification)
-
-                    git
-                        .add()
-                        .addFilepattern("pom.xml")
-                        .call()
-
-                    git
-                        .commit()
-                        .setAuthor(PersonIdent("dependency-update-bot", ""))
-                        .setMessage("Bump $update.artifactId from $update.currentVersion to $update.latestVersion")
-                        .call()
-
-                    git
-                        .push()
-                        .setRefSpecs(RefSpec("$branchName:$branchName"))
-                        .apply {
-                            val uri = URIish(connection.removePrefix("scm:git:"))
-
-                            when (uri.scheme) {
-                                "https" -> {
-                                    val (username, password) = usernamePassword(uri)
-
-                                    setCredentialsProvider(UsernamePasswordCredentialsProvider(username, password))
-                                }
-                                else -> {
-                                    setTransportConfigCallback(TransportConfigCallback { transport ->
-                                        if (transport !is SshTransport) return@TransportConfigCallback
-
-                                        transport.sshSessionFactory = object : JschConfigSessionFactory() {
-                                            override fun configure(hc: OpenSshConfig.Host?, session: Session?) {
-                                            }
-
-                                            override fun createDefaultJSch(fs: FS?) =
-                                                settings.getServer(uri.host).run {
-                                                    super.createDefaultJSch(fs).apply { addIdentity(privateKey, passphrase) }
-                                                }
-                                            }
-                                        })
-                                }
-                            }
-                        }
-                        .setPushOptions(listOf("merge_request.create"))
-                        .call()
+                    git.add("pom.xml")
+                    git.commit("dependency-update-bot", "Bump $update.artifactId from $update.currentVersion to $update.latestVersion" )
+                    git.push(branchName)
                 }
         }
     }
 
-    private fun usernamePassword(uri: URIish) =
-        if (uri.user != null) uri.user to uri.pass else settings.getServer(uri.host).run { username to password }
 
-    private fun withGit(f: (Git, String) -> Unit) {
-        val git = Git(
+
+    private fun withGit(f: (GitProvider) -> Unit) {
+        val git = JGitProvider(Git(
             RepositoryBuilder()
                 .readEnvironment()
                 .findGitDir(mavenProject.basedir)
                 .setMustExist(true)
                 .build()
-        )
+        ), connection, settings)
 
-        f(git, git.repository.fullBranch)
+        git.use{
+            f(git)
+        }
 
-        git.close()
+
     }
 
     private fun withPom(f: (Document) -> Unit) {


### PR DESCRIPTION
This PR extract the Git Provider implementation in a separate class, so that introducing a new Git provider should be easier.

Further improvements
- simplify local build
- move release relevant steps to own profile
- add JUnit 5 dep

Co-authored-by: Georg Berky <georgberky@users.noreply.github.com>